### PR TITLE
feat: added liquidateCalculateSeizeTokens view

### DIFF
--- a/contracts/CToken.py
+++ b/contracts/CToken.py
@@ -461,6 +461,20 @@ class CToken(CTI.CTokenInterface, Exponential.Exponential, SweepTokens.SweepToke
     def borrowBalanceStored(self, params):
         sp.set_type(params, sp.TAddress)
         sp.result(self.getBorrowBalance(params))
+    
+    """    
+        Return the borrow balance of account based on stored data
+
+        dev: Do accrueInterest() before this function to get the up-to-date borrow balance
+
+        params: TAddress - The address whose balance should be calculated
+
+        return: The calculated balance
+    """
+    @sp.onchain_view()
+    def borrowBalanceStoredView(self, params):
+        sp.set_type(params, sp.TAddress)
+        sp.result(self.getBorrowBalance(params))
 
     def getBorrowBalance(self, account):
         borrowSnapshot = sp.local('borrowSnapshot', self.data.balances[account].accountBorrows)

--- a/contracts/Comptroller.py
+++ b/contracts/Comptroller.py
@@ -329,11 +329,23 @@ class Comptroller(CMPTInterface.ComptrollerInterface, Exponential.Exponential, S
     @sp.utils.view(sp.TInt)
     def returnHypoAccountLiquidity(self, params):
         sp.set_type(params, CMPTInterface.TAccountLiquidityParams)
+        liquidity = self.getHypoAccountLiquidityInternal(params)
+        sp.result(liquidity)
+    
+    def getHypoAccountLiquidityInternal(self, params):
+        sp.set_type(params, CMPTInterface.TAccountLiquidityParams)
         calcLiquidity = sp.local('calcLiquidity', self.calculateAccountLiquidityWithView(sp.record(cTokenModify=sp.some(
             params.cTokenModify), account=params.account, redeemTokens=params.redeemTokens, borrowAmount=params.borrowAmount))).value
         liquidity = sp.compute(
             calcLiquidity.sumCollateral - calcLiquidity.sumBorrowPlusEffects)
-        sp.result(liquidity)
+        return liquidity
+    
+    def getAccountLiquidityInternal(self, account):
+        calcLiquidity = sp.local('calcLiquidity', self.calculateAccountLiquidityWithView(sp.record(
+            cTokenModify=sp.none, account=account, redeemTokens=sp.nat(0), borrowAmount=sp.nat(0)))).value
+        liquidity = sp.compute(
+            calcLiquidity.sumCollateral - calcLiquidity.sumBorrowPlusEffects)
+        return liquidity
 
     """
         Determines the amount of collateral tokens that can seized given the 
@@ -354,7 +366,7 @@ class Comptroller(CMPTInterface.ComptrollerInterface, Exponential.Exponential, S
             priceCollateralMantissa.value.mantissa == sp.nat(0)), EC.CMPT_PRICE_ERROR)
 
         exchangeRateMantissa = sp.view("exchangeRateStoredView", params.cTokenCollateral, sp.unit,
-                                       t=sp.TNat).open_some("INVALID ACCOUNT SNAPSHOT VIEW")
+                                       t=sp.TNat).open_some("INVALID EXCHANGE RATE VIEW")
 
         numerator = sp.local("numerator", self.mul_exp_exp(self.makeExp(
             self.data.liquidationIncentiveMantissa), priceBorrowedMantissa.value))
@@ -366,6 +378,33 @@ class Comptroller(CMPTInterface.ComptrollerInterface, Exponential.Exponential, S
 
         sp.result(self.mulScalarTruncate(
             ratio.value, params.actualRepayAmount))
+    
+    """
+        Determines whether a users position can be liquidated
+
+        return: TBool - return true if position can be liquidated else errors out
+    """
+    @sp.onchain_view()
+    def liquidateBorrowAllowed(self, params):
+        sp.set_type(params, CMPTInterface.TLiquidateBorrowAllowed)
+        # liquidator is not used, left here for future proofing
+        
+        self.verifyMarketListed(params.cTokenBorrowed)
+        self.verifyMarketListed(params.cTokenCollateral)
+
+        liquidity = sp.local("liquidtiy", self.getAccountLiquidityInternal(params.borrower))
+
+        sp.verify(liquidity.value < 0, EC.CMPT_INSUFFICIENT_SHORTFALL)
+        
+        borrowBalance = sp.view("borrowBalanceStoredView", params.cTokenBorrowed, params.borrower,
+                                       t=sp.TNat).open_some("INVALID ACCOUNT BORROW BALANCE VIEW")
+        
+        maxClose = sp.local("maxClose", self.mulScalarTruncate(self.makeExp(
+            self.data.closeFactorMantissa), borrowBalance))
+       
+        sp.verify(maxClose.value >= params.repayAmount, EC.CMPT_TOO_MUCH_REPAY)
+
+        sp.result(True)
 
     def calculateCurrentAccountLiquidityWithView(self, account):
         return self.calculateAccountLiquidityWithView(sp.record(cTokenModify=sp.none, account=account, redeemTokens=sp.nat(0), borrowAmount=sp.nat(0)))

--- a/contracts/errors/ComptrollerErrors.py
+++ b/contracts/errors/ComptrollerErrors.py
@@ -23,3 +23,5 @@ class ErrorCodes:
     CMPT_LIQUIDITY_OLD = "CMPT_LIQUIDITY_OLD" # Liquidity is too old
 
     CMPT_PRICE_ERROR = "CMPT_PRICE_ERROR" # invalid price from oracle
+    CMPT_INSUFFICIENT_SHORTFALL = "CMPT_INSUFFICIENT_SHORTFALL" # insufficient shortfall to liquidate a users position
+    CMPT_TOO_MUCH_REPAY = "CMPT_TOO_MUCH_REPAY" # liquidation repay amount larger than possible liquidation

--- a/contracts/interfaces/ComptrollerInterface.py
+++ b/contracts/interfaces/ComptrollerInterface.py
@@ -4,20 +4,30 @@
 import smartpy as sp
 
 
-TMintAllowedParams = sp.TRecord(cToken=sp.TAddress, minter=sp.TAddress, mintAmount=sp.TNat).layout(("cToken", ("minter", "mintAmount")))
-TBorrowAllowedParams = sp.TRecord(cToken=sp.TAddress, borrower=sp.TAddress, borrowAmount=sp.TNat).layout(("cToken", ("borrower", "borrowAmount")))
-TRedeemAllowedParams = sp.TRecord(cToken=sp.TAddress, redeemer=sp.TAddress, redeemAmount=sp.TNat).layout(("cToken", ("redeemer", "redeemAmount")))
-TRepayBorrowAllowedParams = sp.TRecord(cToken=sp.TAddress, payer=sp.TAddress, borrower=sp.TAddress, repayAmount=sp.TNat).layout(("cToken", ("payer", ("borrower", "repayAmount"))))
-TTransferAllowedParams = sp.TRecord(cToken=sp.TAddress, src=sp.TAddress, dst=sp.TAddress, transferTokens=sp.TNat).layout((("cToken", "src"), ("dst", "transferTokens")))
+TMintAllowedParams = sp.TRecord(cToken=sp.TAddress, minter=sp.TAddress, mintAmount=sp.TNat).layout(
+    ("cToken", ("minter", "mintAmount")))
+TBorrowAllowedParams = sp.TRecord(cToken=sp.TAddress, borrower=sp.TAddress, borrowAmount=sp.TNat).layout(
+    ("cToken", ("borrower", "borrowAmount")))
+TRedeemAllowedParams = sp.TRecord(cToken=sp.TAddress, redeemer=sp.TAddress, redeemAmount=sp.TNat).layout(
+    ("cToken", ("redeemer", "redeemAmount")))
+TRepayBorrowAllowedParams = sp.TRecord(cToken=sp.TAddress, payer=sp.TAddress, borrower=sp.TAddress, repayAmount=sp.TNat).layout(
+    ("cToken", ("payer", ("borrower", "repayAmount"))))
+TTransferAllowedParams = sp.TRecord(cToken=sp.TAddress, src=sp.TAddress, dst=sp.TAddress,
+                                    transferTokens=sp.TNat).layout((("cToken", "src"), ("dst", "transferTokens")))
 TAccountLiquidityParams = sp.TRecord(cTokenModify=sp.TAddress,
-                             account=sp.TAddress,
-                             redeemTokens=sp.TNat,
-                             borrowAmount=sp.TNat
-                            ).layout(("account", ("cTokenModify", ("redeemTokens", "borrowAmount"))))
-TGetAccountLiquidityParams = sp.TRecord(data=TAccountLiquidityParams, callback=sp.TContract(sp.TInt))
+                                     account=sp.TAddress,
+                                     redeemTokens=sp.TNat,
+                                     borrowAmount=sp.TNat
+                                     ).layout(("account", ("cTokenModify", ("redeemTokens", "borrowAmount"))))
+TGetAccountLiquidityParams = sp.TRecord(
+    data=TAccountLiquidityParams, callback=sp.TContract(sp.TInt))
 
 TLiquidateCalculateSeizeTokens = sp.TRecord(
     cTokenBorrowed=sp.TAddress, cTokenCollateral=sp.TAddress, actualRepayAmount=sp.TNat)
+
+TLiquidateBorrowAllowed = sp.TRecord(
+    cTokenBorrowed=sp.TAddress, cTokenCollateral=sp.TAddress, borrower=sp.TAddress, liquidator=sp.TAddress, repayAmount=sp.TNat)
+
 
 class ComptrollerInterface(sp.Contract):
 
@@ -29,7 +39,6 @@ class ComptrollerInterface(sp.Contract):
     @sp.entry_point
     def enterMarkets(self, cTokens):
         pass
-
 
     """    
         Removes asset from sender's account liquidity calculation
@@ -47,7 +56,6 @@ class ComptrollerInterface(sp.Contract):
     def exitMarket(self, cToken):
         pass
 
-
     """    
         Checks if the account should be allowed to mint tokens in the given market
 
@@ -59,7 +67,6 @@ class ComptrollerInterface(sp.Contract):
     @sp.entry_point
     def mintAllowed(self, params):
         pass
-
 
     """    
         Checks if the account should be allowed to redeem tokens in the given market
@@ -77,7 +84,6 @@ class ComptrollerInterface(sp.Contract):
     def redeemAllowed(self, params):
         pass
 
-
     """    
         Checks if the account should be allowed to borrow the underlying asset of the given market
 
@@ -94,7 +100,6 @@ class ComptrollerInterface(sp.Contract):
     def borrowAllowed(self, params):
         pass
 
-
     """    
         Checks if the account should be allowed to repay a borrow in the given market
 
@@ -107,7 +112,6 @@ class ComptrollerInterface(sp.Contract):
     @sp.entry_point
     def repayBorrowAllowed(self, params):
         pass
-
 
     """    
         Checks if the account should be allowed to transfer tokens in the given market
@@ -125,7 +129,6 @@ class ComptrollerInterface(sp.Contract):
     @sp.entry_point
     def transferAllowed(self, params):
         pass
-
 
     """    
         Determine what the account liquidity would be if the given amounts were redeemed/borrowed
@@ -149,7 +152,6 @@ class ComptrollerInterface(sp.Contract):
     def getHypoAccountLiquidity(self, params):
         pass
 
-
     """    
         Sets a new pending governance for the market
 
@@ -160,7 +162,7 @@ class ComptrollerInterface(sp.Contract):
     @sp.entry_point
     def setPendingGovernance(self, pendingAdminAddress):
         pass
-    
+
     """    
         Accept a new governance for the market
 
@@ -183,7 +185,6 @@ class ComptrollerInterface(sp.Contract):
     def setPriceOracle(self, params):
         pass
 
-
     """    
         Sets the closeFactor used when liquidating borrows
 
@@ -194,7 +195,6 @@ class ComptrollerInterface(sp.Contract):
     @sp.entry_point
     def setCloseFactor(self, params):
         pass
-
 
     """    
         Sets the collateralFactor for a market
@@ -209,7 +209,6 @@ class ComptrollerInterface(sp.Contract):
     def setCollateralFactor(self, params):
         pass
 
-
     """    
         Sets liquidationIncentive
 
@@ -220,7 +219,6 @@ class ComptrollerInterface(sp.Contract):
     @sp.entry_point
     def setLiquidationIncentive(self, params):
         pass
-
 
     """    
         Add the market to the markets mapping and set it as listed
@@ -235,7 +233,6 @@ class ComptrollerInterface(sp.Contract):
     def supportMarket(self, params):
         pass
 
-
     """    
         Disable the supported market
 
@@ -246,7 +243,6 @@ class ComptrollerInterface(sp.Contract):
     @sp.entry_point
     def disableMarket(self, params):
         pass
-
 
     """    
         Set the given borrow cap for the given cToken market. Borrowing that brings total borrows to or above borrow cap will revert.
@@ -261,7 +257,6 @@ class ComptrollerInterface(sp.Contract):
     def setMarketBorrowCap(self, params):
         pass
 
-
     """    
         Pause or activate the mint of given CToken
 
@@ -275,7 +270,6 @@ class ComptrollerInterface(sp.Contract):
     def setMintPaused(self, params):
         pass
 
-
     """    
         Pause or activate the borrow of given CToken
 
@@ -288,7 +282,6 @@ class ComptrollerInterface(sp.Contract):
     @sp.entry_point
     def setBorrowPaused(self, params):
         pass
-
 
     """    
         Pause or activate the transfer of CTokens


### PR DESCRIPTION
Signed-off-by: Soumya Ghosh Dastidar <gdsoumya@gmail.com>

This PR adds `liquidateCalculateSeizeTokens` view for liquidation which helps calculate the number of collateral tokens that can be seized for the liquidation of a given borrowed asset