### PR TITLE
Github action for CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,7 +31,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
     - run: cd src/util
     - run: npm ci
     - run: npm test


### PR DESCRIPTION
To reduce development noise, we must have continuous integration running. 