### PR TITLE
Borrow Repayment (repay full amount) fixed

### DIFF
--- a/src/ui/src/components/BorrowModal/index.js
+++ b/src/ui/src/components/BorrowModal/index.js
@@ -71,11 +71,10 @@ const BorrowModal = (props) => {
 
     const repayBorrowToken = async () => {
         // eslint-disable-next-line no-shadow
+	     
 	    if (new BigNumber(undecimalify(useMaxAmount, decimals[tokenDetails.title]).toString()).eq(new BigNumber(amount))) {
-		    console.log('useMax selected');
-            // multiply the ammount by 2 to make sure all the amount is repaid
-            const { opGroup, error } = await repayBorrowTokenAction(tokenDetails, bigInt(amount).multiply(2).toString(), close, setTokenText, handleOpenInitialize, protocolAddresses, publicKeyHash);
-
+		    // sending the contract total wallet underlyingBalance 
+            const { opGroup, error } = await repayBorrowTokenAction(tokenDetails, account.underlyingBalances[tokenDetails.assetType].value.toString(), close, setTokenText, handleOpenInitialize, protocolAddresses, publicKeyHash);
             setOpGroup(opGroup);
             setEvaluationError(error);
 	    } else {


### PR DESCRIPTION
FIx for issue #117. The borrows are not up to date in the UI , the contract accrues interest that is not reflected in the borrows of the  UI . Even if the UI keeps the market data fresh , the borrow rate will change after the user has selected use max due to other operations and calls by other users causing the borrow index to change . Thus,  the present temporary solution: if the value to repay is the current max amount in the contract send the total wallet balance for the asset to the contract .  

The relevant contract function : repayBorrowInternal , then on line
244 :
`     repayAmount = sp.min(accountBorrows, params.repayAmount)`

Chooses the minimum of the two amounts . Therefore supplying it with
the total wallet balance guarantees that the max amount will be deducted
when the user has selected UseMax and  no remainder should be left. Will not work for xtz till @gdsoumya's e2e branch is merged