### PR TITLE
Removed the extra application of exchange rate

### DIFF
--- a/src/util/src/TezosLendingPlatform.ts
+++ b/src/util/src/TezosLendingPlatform.ts
@@ -176,12 +176,11 @@ export namespace TezosLendingPlatform {
             switch (markets[asset].asset.underlying.tokenStandard) {
                 case TokenStandard.XTZ: // native asset
 
-
-			    balances[asset] = FToken.applyExchangeRate(await GetUnderlyingBalanceXTZ(address, server), markets[asset].storage);
+			    balances[asset] = await GetUnderlyingBalanceXTZ(address, server);
                     break;
                 default: // contract-based assets
 
-			    balances[asset] = FToken.applyExchangeRate(await GetUnderlyingBalanceToken(markets[asset].asset.underlying, address, server), markets[asset].storage);
+			    balances[asset] = await GetUnderlyingBalanceToken(markets[asset].asset.underlying, address, server);
                     break;
             }
         }));


### PR DESCRIPTION
The bug was introduced due to erroneous thinking that the contracts
was returning amounts as FToken that had to be converted to get the
true underlying balance . This was incorrect .