### PR TITLE
Update stale Annual period values

### DIFF
--- a/src/util/src/FToken.ts
+++ b/src/util/src/FToken.ts
@@ -427,8 +427,7 @@ export namespace FToken {
         const _blockRate = getBorrowRate(storage, irStorage);
 
         if (_blockRate.greaterOrEquals(storage.borrow.borrowRateMaxMantissa)) {
-            // return bigint 0 when borrow rate is greater than max borrow rate
-            return bigInt(0);
+            return _calcAnnualizedRate(storage.borrow.borrowRateMaxMantissa, irStorage.scale).multiply(100);
         }
 
         return _calcAnnualizedRate(_blockRate, irStorage.scale).multiply(100);


### PR DESCRIPTION
This pull request addresses a critical issue where the annual period (blocks per year) of the blockchain has doubled, significantly impacting the APY% calculation and display, as well as the rate parameters in our smart contracts. The main goal of this PR is to update the library's annual period parameter to accurately reflect the current blockchain's annual period. This change is crucial for ensuring the APY% displayed to users corresponds to the actual earning potential based on the updated blockchain dynamics.

**Changes**:

Annual Period Adjustment: Updated the annual period parameter in the library to match the blocks per year on the blockchain by providing a utility function parametrized by blocks per minute . This update ensures that the APY% calculation is based on the correct number of blocks per year, providing accurate and reliable data to our users.


**Impact**:

 User Experience: Improves the accuracy of the APY% displayed to users
 Contract Alignment: Ensures that the APY  calculations are in  alignment with the contract's logic, especially in edge conditions.
    These previous PR's are affected by the changes in annual period : https://github.com/StableTechnologies/TezFin/pull/194, https://github.com/StableTechnologies/TezFin/pull/177

**Further work**:

- Update unit tests to cover the new annual period calculations.
- Update the IRM & CToken contracts to reflect to new block Rate .
- Monitor a large amount over a period of 10 and 30 days  to confirm no further issues exist in the APY's.

Screenshot: 


![annual_period](https://github.com/StableTechnologies/TezFin/assets/424818/6b3de3cc-37c2-47e2-b57e-54a23f034574)
