### PR TITLE
fix: ui issues with borrow and repay

### DIFF
--- a/src/ui/src/components/BorrowModal/index.js
+++ b/src/ui/src/components/BorrowModal/index.js
@@ -53,8 +53,8 @@ const BorrowModal = (props) => {
     const [pendingLimit, setPendingLimit] = useState('');
     const [pendingLimitUsed, setPendingLimitUsed] = useState('');
 
-    const buttonOne = useBorrowErrorText(tokenValue, useMaxAmount, tokenDetails);
-    const buttonTwo = useRepayErrorText(tokenValue, useMaxAmount);
+    const buttonOne = useBorrowErrorText(tokenValue,borrowLimit, tokenDetails);
+    const buttonTwo = useRepayErrorText(tokenValue, useMaxAmount, tokenDetails);
 
     const handleOpenInitialize = () => setInitializeModal(true);
     const handleCloseInitialize = () => setInitializeModal(false);

--- a/src/ui/src/components/DashboardModal/index.js
+++ b/src/ui/src/components/DashboardModal/index.js
@@ -463,8 +463,8 @@ const DashboardModal = (props) => {
                                         <Typography className={classes.warningText}>
                                             {!isKeyRevealed
                                                 ? 'You need to perform a reveal operation with your new wallet (for example send XTZ) in order to interact with TezFin.'
-                                                : new BigNumber(tezBalance).lt(0.25) &&
-                                                  "Your XTZ balance is low. You may soon not be able to process any new operation if you don't add XTZ to your wallet."}
+                                                : new BigNumber(tezBalance).lt(0.25)
+                                                && 'Your XTZ balance is low. You may soon not be able to process any new operation if you don\'t add XTZ to your wallet.'}
                                         </Typography>
                                     </>
                                 ) : (


### PR DESCRIPTION
- repay will check you wallet balance first and stop users from repaying if the amount is greater than their wallet balance.
- borrow max limit is fixed previously it wouldn't allow anyone to borrow beyond the 50% of their limit.