### PR TITLE
Update TezFinOracleTest to use '-USDT' naming convention

### DIFF
--- a/contracts/tests/TezFinOracleTest.py
+++ b/contracts/tests/TezFinOracleTest.py
@@ -44,15 +44,15 @@ def test():
     scenario.h2("Tezfin Oracle")
     tezfinOracle = TezFinOracle(admin.address, harbinger.address)
     scenario += tezfinOracle
-    harbinger.setPrice([sp.record(asset="ETHUSDT", price=13425)]
+    harbinger.setPrice([sp.record(asset="ETH-USDT", price=13425)]
                        ).run(sender=alice, valid=False, now=sp.timestamp(16534534))
-    harbinger.setPrice([sp.record(asset="ETHUSDT", price=13425), sp.record(
-        asset="BTCUSDT", price=2342354345)]).run(sender=admin, now=sp.timestamp(16534534))
-    harbinger.setPrice([sp.record(asset="XTZUSDT", price=203434)]
+    harbinger.setPrice([sp.record(asset="ETH-USDT", price=13425), sp.record(
+        asset="BTC-USDT", price=2342354345)]).run(sender=admin, now=sp.timestamp(16534534))
+    harbinger.setPrice([sp.record(asset="XTZ-USDT", price=203434)]
                        ).run(sender=admin, now=sp.timestamp(16534534))
-    tezfinOracle.setPrice([sp.record(asset="FINUSDT", price=1000000)]
+    tezfinOracle.setPrice([sp.record(asset="FIN-USDT", price=1000000)]
                           ).run(sender=admin, now=sp.timestamp(16534534))
-    tezfinOracle.removeAsset("FIN-USD").run(sender=admin)
+    tezfinOracle.removeAsset("FIN-USDT").run(sender=admin)
     tezfinOracle.addAlias([sp.record(
         asset="XTZ-USD", alias="WTZ-USD"), sp.record(
         asset="XTZ-USD", alias="RRXTZ-USD"), sp.record(asset="XTZ-USD", alias="oXTZ-USD")]).run(sender=admin, now=sp.timestamp(16534534))


### PR DESCRIPTION
This commit updates the test configuration in TezFinOracleTest.py to align with the new '-USDT' naming convention used by the oracle integration.

Previously, assets were set and tested with names like 'ETHUSDT' or 'XTZUSDT'. Since the oracle now expects pairs like 'ETH-USDT' and 'XTZ-USDT', this commit inserts the missing dash before 'USDT' in all relevant asset names. Additionally, the removeAsset call is updated to remove 'FIN-USDT' instead of 'FIN-USD', ensuring consistency and accuracy across the test.

With these changes, the test and the oracle logic are fully synchronized, preventing naming mismatches and restoring proper functionality to the price retrieval tests.