### PR TITLE
Use '-USDT' naming convention in oracle and tests

### DIFF
--- a/contracts/TezFinOracle.py
+++ b/contracts/TezFinOracle.py
@@ -97,7 +97,7 @@ class TezFinOracle(OracleInterface.OracleInterface):
             sp.if self.data.alias.contains(requestedAsset):
                 asset.value = self.data.alias[requestedAsset]
             sliced_asset = sp.slice(asset.value, 0, sp.as_nat(sp.len(asset.value) - 4)).open_some("failed to convert asset name")
-            oracle_data = sp.view("get_price_with_timestamp", self.data.oracle, sliced_asset+"USDT", t=sp.TPair(
+            oracle_data = sp.view("get_price_with_timestamp", self.data.oracle, sliced_asset+"-USDT", t=sp.TPair(
                 sp.TNat, sp.TTimestamp)).open_some("invalid oracle view call")
             sp.result(oracle_data)
 
@@ -114,6 +114,6 @@ class TezFinOracle(OracleInterface.OracleInterface):
             sp.if self.data.alias.contains(requestedAsset):
                 asset.value = self.data.alias[requestedAsset]
             sliced_asset = sp.slice(asset.value, 0, sp.as_nat(sp.len(asset.value) - 4)).open_some("failed to convert asset name")
-            oracle_data = sp.view("get_price_with_timestamp", self.data.oracle, sliced_asset+"USDT", t=sp.TPair(
+            oracle_data = sp.view("get_price_with_timestamp", self.data.oracle, sliced_asset+"-USDT", t=sp.TPair(
                 sp.TNat, sp.TTimestamp)).open_some("invalid oracle view call")
             sp.result((sp.snd(oracle_data), sp.fst(oracle_data)))

--- a/contracts/tests/TezFinOracleTest.py
+++ b/contracts/tests/TezFinOracleTest.py
@@ -44,15 +44,15 @@ def test():
     scenario.h2("Tezfin Oracle")
     tezfinOracle = TezFinOracle(admin.address, harbinger.address)
     scenario += tezfinOracle
-    harbinger.setPrice([sp.record(asset="ETHUSDT", price=13425)]
+    harbinger.setPrice([sp.record(asset="ETH-USDT", price=13425)]
                        ).run(sender=alice, valid=False, now=sp.timestamp(16534534))
-    harbinger.setPrice([sp.record(asset="ETHUSDT", price=13425), sp.record(
-        asset="BTCUSDT", price=2342354345)]).run(sender=admin, now=sp.timestamp(16534534))
-    harbinger.setPrice([sp.record(asset="XTZUSDT", price=203434)]
+    harbinger.setPrice([sp.record(asset="ETH-USDT", price=13425), sp.record(
+        asset="BTC-USDT", price=2342354345)]).run(sender=admin, now=sp.timestamp(16534534))
+    harbinger.setPrice([sp.record(asset="XTZ-USDT", price=203434)]
                        ).run(sender=admin, now=sp.timestamp(16534534))
-    tezfinOracle.setPrice([sp.record(asset="FINUSDT", price=1000000)]
+    tezfinOracle.setPrice([sp.record(asset="FIN-USDT", price=1000000)]
                           ).run(sender=admin, now=sp.timestamp(16534534))
-    tezfinOracle.removeAsset("FIN-USD").run(sender=admin)
+    tezfinOracle.removeAsset("FIN-USDT").run(sender=admin)
     tezfinOracle.addAlias([sp.record(
         asset="XTZ-USD", alias="WTZ-USD"), sp.record(
         asset="XTZ-USD", alias="RRXTZ-USD"), sp.record(asset="XTZ-USD", alias="oXTZ-USD")]).run(sender=admin, now=sp.timestamp(16534534))


### PR DESCRIPTION
This pull request updates both the oracle contract and the corresponding tests to consistently use the "-USDT" naming convention. Previously, assets were referenced with a direct "USDT" suffix (e.g., "ETHUSDT") and the oracle code appended "USDT" without a dash. This mismatch caused tests to fail after switching from Harbinger to Youves oracle data, which expects a dash before "USDT" (e.g., "ETH-USDT").

Key Changes:
	•	In TezFinOracle.py, replaced occurrences of sliced_asset+"USDT" with sliced_asset+"-USDT".
	•	In TezFinOracleTest.py, updated all instances of ASSETUSDT (like ETHUSDT, XTZUSDT) to ASSET-USDT (e.g., ETH-USDT, XTZ-USDT) to align with the updated oracle logic.
	•	Corrected removeAsset("FIN-USD") to removeAsset("FIN-USDT") to maintain consistency.

By combining both sets of changes into a single PR, the tests should now pass and accurately reflect the naming convention Youves expects. This ensures smoother maintenance and fewer naming-related issues in the future.