### PR TITLE
fix: preserve amount field in Taquito operations for XTZ repayments

### DIFF
--- a/src/util/src/TezosLendingPlatform.ts
+++ b/src/util/src/TezosLendingPlatform.ts
@@ -1278,7 +1278,7 @@ export namespace TezosLendingPlatform {
               to: opt.destination,
               kind: OpKind.TRANSACTION,
               source: opt.source,
-              amount: parseInt(opt.amount) || 0,
+              amount: Number(opt.amount) || 0,
               parameter: opt.parameters as TransactionOperationParameter,
             });
             break;


### PR DESCRIPTION
Previously, when converting operations to Taquito-compatible formats, the amount field set by our repayment logic for XTZ-denominated markets was not properly preserved. This caused the contract to never receive the intended tez amount for XTZ repayments, resulting in failed repayment attempts.

This commit ensures that the amount field is always interpreted and transferred correctly as a numeric value. By converting opt.amount using the Number() constructor, we guarantee that whether it’s originally a string or a number, it will be handled properly. If opt.amount is missing or cannot be parsed into a number, it safely defaults to zero, preventing runtime errors.

With this change, XTZ repayments once again send the correct amount of tez to the contract, restoring the intended functionality and allowing borrowers to successfully repay their XTZ loans.

No changes to existing tests were required, since this issue involved the interpretation of the amount field in actual transactions, not the internal math or logic tested in the current test suite.