### PR TITLE
feat: table sticky columns

### DIFF
--- a/src/ui/src/components/Dashboard/BorrowMarketTokenTable.tsx
+++ b/src/ui/src/components/Dashboard/BorrowMarketTokenTable.tsx
@@ -54,10 +54,13 @@ const BorrowMarketTokenTable = (props) => {
             <Table>
                 <TableHead>
                     <TableRow>
-                        <TableCell> Token </TableCell>
+                        <TableCell className={classes.stickyCellLeft}>
+                            Token
+                        </TableCell>
                         <TableCell align="center"> Available </TableCell>
                         <TableCell align="center"> Borrow APY </TableCell>
-                        <TableCell align="center"> </TableCell>
+                        <TableCell align="center" className={classes.stickyCellRight}> </TableCell>
+                        <TableCell align="center" className={classes.fifthCell}> </TableCell>
                     </TableRow>
                 </TableHead>
                 <TableBody>
@@ -65,22 +68,20 @@ const BorrowMarketTokenTable = (props) => {
                         <React.Fragment key={data.title}>
                             {(address && data.walletBalance) || (!address && data.marketSize) ? (
                                 <TableRow key={data.title}>
-                                    <TableCell className={classes.firstCell}>
-                                        <div>
-                                            <div className={classes.token}>
-                                                <img
-                                                    src={data.logo}
-                                                    alt={`${data.title}-Icon`}
-                                                    className={classes.img}
-                                                />
+                                    <TableCell className={`${classes.firstCell} ${classes.stickyCellLeft}`}>
+                                        <div className={classes.token}>
+                                            <img
+                                                src={data.logo}
+                                                alt={`${data.title}-Icon`}
+                                                className={classes.img}
+                                            />
 
-                                                <div className={classes.tokenTitle}>
-                                                    <Typography className={classes.tokenName}> {data.name} </Typography>
-                                                    <Typography className={classes.faintFont}>
-                                                        {' '}
-                                                        {data.title}{' '}
-                                                    </Typography>
-                                                </div>
+                                            <div className={classes.tokenTitle}>
+                                                <Typography className={classes.tokenName}> {data.name} </Typography>
+                                                <Typography className={classes.faintFont}>
+                                                    {' '}
+                                                    {data.title}{' '}
+                                                </Typography>
                                             </div>
                                         </div>
                                     </TableCell>
@@ -131,24 +132,24 @@ const BorrowMarketTokenTable = (props) => {
                                             %
                                         </span>
                                     </TableCell>
-                                    <TableCell align="center" className={classes.fifthCell}>
-                                        <span>
-                                            <Button
-                                                variant="contained"
-                                                size="medium"
-						className={classes.borrowButton}
-                                                onClick={() => handleClickMktModal(data)}
-                                            >
-                                                B<Typography textTransform={'lowercase'}>orrow</Typography>
-                                            </Button>
-                                            <Button
-                                                variant="contained"
-                                                size="medium"
-						className={classes.detailsButton}
-                                            >
+                                    <TableCell className={classes.stickyCellRight}>
+                                        <Button
+                                            variant="contained"
+                                            size="medium"
+                                            className={classes.borrowButton}
+                                            onClick={() => handleClickMktModal(data)}
+                                        >
+                                            B<Typography textTransform={'lowercase'}>orrow</Typography>
+                                        </Button>
+                                    </TableCell>
+                                    <TableCell className={classes.fifthCell}>
+                                        <Button
+                                            variant="contained"
+                                            size="medium"
+						                    className={classes.detailsButton}
+                                        >
                                                 D<Typography textTransform={'lowercase'}>etails</Typography>
-                                            </Button>
-                                        </span>
+                                        </Button>
                                     </TableCell>
                                 </TableRow>
                             ) : (

--- a/src/ui/src/components/Dashboard/SupplyMarketTokenTable.tsx
+++ b/src/ui/src/components/Dashboard/SupplyMarketTokenTable.tsx
@@ -46,10 +46,12 @@ const SupplyMarketTokenTable = (props) => {
             <Table size="medium" sx={{ marginRight: '0px' }}>
                 <TableHead>
                     <TableRow>
-                        <TableCell> Token </TableCell>
+                        <TableCell className={classes.stickyCellLeft}>
+                            Token
+                        </TableCell>
                         <TableCell align="center"> Wallet </TableCell>
                         <TableCell align="center"> Supply APY </TableCell>
-                        <TableCell align="center"> </TableCell>
+                        <TableCell className={classes.stickyCellRight} align="center"> </TableCell>
                     </TableRow>
                 </TableHead>
                 <TableBody>
@@ -57,22 +59,20 @@ const SupplyMarketTokenTable = (props) => {
                         <React.Fragment key={data.title}>
                             {(address && data.walletBalance) || (!address && data.marketSize) ? (
                                 <TableRow key={data.title} onClick={() => handleClickMktModal(data)}>
-                                    <TableCell className={classes.firstCell}>
-                                        <div>
-                                            <div className={classes.token}>
-                                                <img
-                                                    src={data.logo}
-                                                    alt={`${data.title}-Icon`}
-                                                    className={classes.img}
-                                                />
+                                    <TableCell className={`${classes.firstCell} ${classes.stickyCellLeft}`}>
+                                        <div className={classes.token}>
+                                            <img
+                                                src={data.logo}
+                                                alt={`${data.title}-Icon`}
+                                                className={classes.img}
+                                            />
 
-                                                <div className={classes.tokenTitle}>
-                                                    <Typography className={classes.tokenName}> {data.name} </Typography>
-                                                    <Typography className={classes.faintFont}>
-                                                        {' '}
-                                                        {data.title}{' '}
-                                                    </Typography>
-                                                </div>
+                                            <div className={classes.tokenTitle}>
+                                                <Typography className={classes.tokenName}> {data.name} </Typography>
+                                                <Typography className={classes.faintFont}>
+                                                    {' '}
+                                                    {data.title}{' '}
+                                                </Typography>
                                             </div>
                                         </div>
                                     </TableCell>
@@ -120,7 +120,7 @@ const SupplyMarketTokenTable = (props) => {
                                             %
                                         </span>
                                     </TableCell>
-                                    <TableCell align="center" className={classes.fourthCell}>
+                                    <TableCell align="center" className={`${classes.fourthCell} ${classes.stickyCellRight}`}>
                                         <span>
                                             <Button
                                                 variant="contained"

--- a/src/ui/src/components/Dashboard/style.ts
+++ b/src/ui/src/components/Dashboard/style.ts
@@ -151,12 +151,9 @@ export const useStyles = makeStyles({
     borrowButton: {
         marginRight: '0%',
         borderRadius: '8px',
-        right: '10%',
-        '@media(max-width: 900px)': {
-            right: '10%',
-        },
         '@media(max-width: 768px)': {},
         '@media(max-width: 501px)': {},
+        width: '80%'
     },
     detailsButton: {
         color: '#2C2C2C',
@@ -167,6 +164,7 @@ export const useStyles = makeStyles({
             backgroundColor: 'lightgrey',
             boxShadow: 'none',
         },
+        width: '80%'
     },
     tokenName: {
         display: 'inline',
@@ -252,12 +250,17 @@ export const useStyles = makeStyles({
         width: '30%',
     },
     fifthCell: {
-        width: '30%',
+        width: '15%',
         right: '10px',
+        '@media(max-width: 1300px)': {
+            opacity: '1 !important',
+        },
+        paddingLeft: '1px !important',
+        backgroundColor: '#ECF4FF'
     },
     supplyButton: {
         borderRadius: '8px',
-        marginRight: '50%',
+        marginRight: '25%',
         marginLeft: '0%',
         width: '80%',
     },
@@ -306,5 +309,23 @@ export const useStyles = makeStyles({
         '@media(min-width: 1200px)': {
             paddingRight: '4rem !important',
         },
+    },
+    stickyCellLeft: {
+        '@media(max-width: 1300px)': {
+            position: 'sticky',
+            zIndex: 2,
+            left: 0,
+            opacity: '1 !important',
+        },
+        backgroundColor: '#ECF4FF'
+    },
+    stickyCellRight: {
+        '@media(max-width: 1300px)': {
+            position: 'sticky',
+            zIndex: 2,
+            right: 0,
+            opacity: '1 !important',
+        },
+        backgroundColor: '#ECF4FF'
     },
 });


### PR DESCRIPTION
Columns now appear sticky.
![tezfinColumns1](https://github.com/user-attachments/assets/fa5f86be-a031-42a2-87db-70794e0ec70b)
For Borrow Market table only 'borrow' button appear sticky. Explanation:
 1. Originally it was column with two action buttons (borrow/details) , if sticky applied they block the view which makes it not user-friendly (user can`t see columns in between).
 2. I split them into a separate columns and applied sticky behavior only for 'borrow' button. This way user always sees the 'borrow' button with ability to scroll to the right for details (see the screens below).
 
![tezfinColumnsPhoneView1](https://github.com/user-attachments/assets/d2b15f39-f459-4d1b-a0c9-49047b9e5217)
![tezfinColumnsPhoneView2](https://github.com/user-attachments/assets/9cb56776-f0c4-41c5-bc12-cd963c8c4584)
![tezfinColumns2](https://github.com/user-attachments/assets/da3dbe90-5e10-4dac-ab67-88942acd0154)
 