### PR TITLE
fix: added footer spacing, actions for borrow market table

### DIFF
--- a/src/ui/src/components/Dashboard/BorrowMarketTokenTable.tsx
+++ b/src/ui/src/components/Dashboard/BorrowMarketTokenTable.tsx
@@ -5,7 +5,7 @@
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import { decimals } from 'tezoslendingplatformjs';
+import { AssetType, decimals, mainnetAddresses, testnetAddresses } from 'tezoslendingplatformjs';
 import BigNumber from 'bignumber.js';
 
 import Table from '@mui/material/Table';
@@ -35,9 +35,13 @@ const BorrowMarketTokenTable = (props) => {
         setMktModal(false);
     };
 
-    const handleClickDetails = (address) => {
+    const handleClickDetails = (asset: AssetType) => {
+        const fTokenAddress = 
+            process.env.REACT_APP_ENV == 'dev' ? testnetAddresses.fTokens[asset] : mainnetAddresses.fTokens[asset];
         const tzktUrl =
-            process.env.REACT_APP_ENV == 'dev' ? `https://ghostnet.tzkt.io/${address}` : `https://tzkt.io/${address}`;
+            process.env.REACT_APP_ENV == "dev"
+                ? `https://ghostnet.tzkt.io/${fTokenAddress}/operations`
+                : `https://tzkt.io/${fTokenAddress}/operations`;
         window.open(tzktUrl, '_blank');
     };
 
@@ -54,7 +58,9 @@ const BorrowMarketTokenTable = (props) => {
             <Table>
                 <TableHead>
                     <TableRow>
-                        <TableCell>Token</TableCell>
+                        <TableCell className={classes.stickyCellLeft}>
+                            Token
+                        </TableCell>
                         <TableCell align="center"> Available </TableCell>
                         <TableCell align="center"> Borrow APY </TableCell>
                         <TableCell align="center" className={classes.stickyCellRight}> </TableCell>
@@ -66,7 +72,7 @@ const BorrowMarketTokenTable = (props) => {
                         <React.Fragment key={data.title}>
                             {(address && data.walletBalance) || (!address && data.marketSize) ? (
                                 <TableRow key={data.title}>
-                                    <TableCell className={classes.firstCell}>
+                                    <TableCell className={`${classes.firstCell} ${classes.stickyCellLeft} ${classes.stickyCellHover}`}>
                                         <div className={classes.token}>
                                             <img
                                                 src={data.logo}
@@ -130,7 +136,7 @@ const BorrowMarketTokenTable = (props) => {
                                             %
                                         </span>
                                     </TableCell>
-                                    <TableCell className={`${classes.stickyCellRight} ${classes.borrowCell}`}>
+                                    <TableCell className={`${classes.stickyCellRight} ${classes.borrowCell} ${classes.stickyCellHover}`}>
                                         <Button
                                             variant="contained"
                                             size="medium"
@@ -145,6 +151,7 @@ const BorrowMarketTokenTable = (props) => {
                                             variant="contained"
                                             size="medium"
 						                    className={classes.detailsButton}
+                                            onClick={() => handleClickDetails(data.assetType)}
                                         >
                                                 D<Typography textTransform={'lowercase'}>etails</Typography>
                                         </Button>

--- a/src/ui/src/components/Dashboard/SupplyMarketTokenTable.tsx
+++ b/src/ui/src/components/Dashboard/SupplyMarketTokenTable.tsx
@@ -51,7 +51,7 @@ const SupplyMarketTokenTable = (props) => {
                         </TableCell>
                         <TableCell align="center"> Wallet </TableCell>
                         <TableCell align="center"> Supply APY </TableCell>
-                        <TableCell align="center"> </TableCell>
+                        <TableCell className={classes.stickyCellRight} align="center"> </TableCell>
                     </TableRow>
                 </TableHead>
                 <TableBody>
@@ -59,7 +59,7 @@ const SupplyMarketTokenTable = (props) => {
                         <React.Fragment key={data.title}>
                             {(address && data.walletBalance) || (!address && data.marketSize) ? (
                                 <TableRow key={data.title} onClick={() => handleClickMktModal(data)}>
-                                    <TableCell className={`${classes.firstCell} ${classes.stickyCellLeft}`}>
+                                    <TableCell className={`${classes.firstCell} ${classes.stickyCellLeft} ${classes.stickyCellHover}`}>
                                         <div className={classes.token}>
                                             <img
                                                 src={data.logo}
@@ -120,7 +120,7 @@ const SupplyMarketTokenTable = (props) => {
                                             %
                                         </span>
                                     </TableCell>
-                                    <TableCell align="center" className={classes.fourthCell}>
+                                    <TableCell align="center" className={`${classes.fourthCell} ${classes.stickyCellRight} ${classes.stickyCellHover}`}>
                                         <span>
                                             <Button
                                                 variant="contained"

--- a/src/ui/src/components/Dashboard/style.ts
+++ b/src/ui/src/components/Dashboard/style.ts
@@ -153,6 +153,7 @@ export const useStyles = makeStyles({
         borderRadius: '8px',
         '@media(max-width: 768px)': {},
         '@media(max-width: 501px)': {},
+        width: '100%',
     },
     detailsButton: {
         color: '#2C2C2C',
@@ -163,6 +164,7 @@ export const useStyles = makeStyles({
             backgroundColor: 'lightgrey',
             boxShadow: 'none',
         },
+        width: '100%',
     },
     tokenName: {
         display: 'inline',
@@ -194,6 +196,7 @@ export const useStyles = makeStyles({
     dashboard: {
         paddingLeft: '6.25rem',
         paddingRight: '6.25rem',
+        paddingBottom: '1.5rem',
         '@media(max-width: 1024px)': {
             paddingLeft: '4rem',
             paddingRight: '4rem',
@@ -319,21 +322,26 @@ export const useStyles = makeStyles({
         },
     },
     stickyCellLeft: {
-        '@media(max-width: 1300px)': {
-            position: 'sticky',
-            zIndex: 2,
-            left: 0,
-            opacity: '1 !important',
-            backgroundColor: 'white',
-        },
+        position: 'sticky',
+        zIndex: 2,
+        left: 0,
+        opacity: '1 !important',
+        backgroundColor: 'white',
+        borderBottom: '0 !important',
+        boxShadow: 'inset 0 -1px 0 #E0E0E0',
     },
     stickyCellRight: {
-        '@media(max-width: 1300px)': {
-            position: 'sticky',
-            zIndex: 2,
-            right: 0,
-            opacity: '1 !important',
-            backgroundColor: 'white',
-        },
+        position: 'sticky',
+        zIndex: 2,
+        right: 0,
+        opacity: '1 !important',
+        backgroundColor: 'white',
+        boxShadow: 'inset 0 -1px 0 #E0E0E0',
+        borderBottom: '0 !important',
     },
+    stickyCellHover: {
+        '.MuiTableRow-root:hover &': {
+            backgroundColor: '#F5FCFE',
+        }
+    }
 });


### PR DESCRIPTION
![actionsSizing](https://github.com/user-attachments/assets/617db3d2-af1e-4a9d-a4bf-63d1ee70ddf0)
Added padding
![footerPadding](https://github.com/user-attachments/assets/f69bf809-8c60-4e40-999b-7aebe67cae15)
Made columns always sticky. The reason they were not sticky at bigger screen size is to avoid weird behavior. For sticky columns their background color has to be set with opacity 1, this way the background would sometimes overlap the border and it would not be displayed. To fix this now we additionally display border with boxShadow for sticky columns. Additionally added change in color (hover) for sticky columns that would be as close to other columns as possible.
![alwaysSticky](https://github.com/user-attachments/assets/880fb5c4-d1d1-4cbc-a68e-d7a31a340cb9)
