### PR TITLE
chore: moved from ECAD RPC to TzKT RPC

### DIFF
--- a/src/ui/src/library/mainnet-network-config.json
+++ b/src/ui/src/library/mainnet-network-config.json
@@ -1,6 +1,6 @@
 {
   "infra": {
-    "tezosNode": "https://mainnet.ecadinfra.com",
+    "tezosNode": "https://rpc.tzkt.io/mainnet",
     "conseilServer": {
         "url": "https://conseil-prod.cryptonomic-infra.tech:443",
         "apiKey": "",


### PR DESCRIPTION
Evaluated three public Tezos mainnet RPC providers (Tezos Foundation, SmartPy, TzKT) under ramp load up to 50 RPS.

Tezos Foundation showed 100% timeouts on cold start and silent request drops under higher load. SmartPy starts throttling with 429s around 30 RPS. TzKT maintained 100% success rate across all test steps with no errors or rate limiting detected.