### PR TITLE
Downgrade @airgap/beacon-sdk to version 4.6.4

### DIFF
--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "private": true,
   "dependencies": {
-    "@airgap/beacon-sdk": "^4.7.0",
+    "@airgap/beacon-sdk": "4.6.4",
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.3.0",


### PR DESCRIPTION
Pins @airgap/beacon-sdk to 4.6.4 as an emergency rollback after wallet connection began failing across browsers with Beacon showing “No server responded.”

Browser console shows Beacon relay requests to beacon-node-*.papers.tech being blocked by CORS before wallet permissions can complete. This change removes the version range and pins the previous known Beacon SDK version exactly so npm does not resolve to a newer 4.x release during install.

This is intended as a fast rollback test to restore wallet connectivity while the Beacon relay/CORS issue is investigated.